### PR TITLE
Add post-update reminder to resubmit Goggle URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,3 +3,7 @@
 A public repo for [Brave Search Goggles](https://search.brave.com/help/goggles)
 
 Note: I do not endorse the instances/websites in this project as I do not have first-hand experience with all of them.
+
+## After updating
+
+After pushing changes to this repo, **resubmit the Goggle URL** at [search.brave.com/goggles/create](https://search.brave.com/goggles/create) to trigger a re-fetch and cache refresh. See the [Goggles getting-started guide](https://github.com/brave/goggles-quickstart/blob/main/getting-started.md) for more details.


### PR DESCRIPTION
## Summary
- Adds an "After updating" section to the README
- Documents the required step of resubmitting the Goggle URL at search.brave.com/goggles/create after pushing changes
- Links to the Goggles getting-started guide for more details

## Test plan
- [x] Verify the link to search.brave.com/goggles/create is correct
- [x] Verify the link to the Goggles getting-started guide is correct

🤖 Generated with [Claude Code](https://claude.com/claude-code)